### PR TITLE
Add gitignore for templates

### DIFF
--- a/template-preact/.gitignore
+++ b/template-preact/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/template-react/.gitignore
+++ b/template-react/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/template-vue/.gitignore
+++ b/template-vue/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist


### PR DESCRIPTION
Currently `.gitignore` is only present in the root directory, the `dist` in it doesn't seem to affect anything since nothing will be built there. Templates that are scaffolded do not contain `.gitignore`.

I've added `.gitignore` to all 3 templates in this PR.