### PR TITLE
feat: add jsdoc for vite.config.js

### DIFF
--- a/template-preact/vite.config.js
+++ b/template-preact/vite.config.js
@@ -1,6 +1,12 @@
-const preactRefresh = require('@prefresh/vite');
+// @ts-check
+const preactRefresh = require('@prefresh/vite')
 
-module.exports = {
+/**
+ * @type { import('vite').UserConfig }
+ */
+const config = {
   jsx: 'preact',
   plugins: [preactRefresh()]
 }
+
+module.exports = config

--- a/template-react/vite.config.js
+++ b/template-react/vite.config.js
@@ -1,4 +1,12 @@
-module.exports = {
+// @ts-check
+const reactPlugin = require('vite-plugin-react')
+
+/**
+ * @type { import('vite').UserConfig }
+ */
+const config = {
   jsx: 'react',
-  plugins: [require('vite-plugin-react')]
+  plugins: [reactPlugin]
 }
+
+module.exports = config

--- a/template-reason-react/vite.config.js
+++ b/template-reason-react/vite.config.js
@@ -1,4 +1,12 @@
-module.exports = {
+// @ts-check
+const reactPlugin = require('vite-plugin-react')
+
+/**
+ * @type { import('vite').UserConfig }
+ */
+const config = {
   jsx: 'react',
-  plugins: [require('vite-plugin-react')],
-};
+  plugins: [reactPlugin]
+}
+
+module.exports = config


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8111351/83170768-9ef7a080-a147-11ea-85c8-850c391f334d.png)
![image](https://user-images.githubusercontent.com/8111351/83170897-d7977a00-a147-11ea-98a6-b45b9919a121.png)

It works for all VSCode without install TypeScript by users.

If somebody need to ignore TypeScript error hint, he just needs to simply remove `// @ts-check`.