### PR TITLE
feat: setState by old value from callback

### DIFF
--- a/template-react-ts/src/App.tsx
+++ b/template-react-ts/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
         <img src={logo} className="App-logo" alt="logo" />
         <p>Hello Vite + React!</p>
         <p>
-          <button onClick={() => setCount(count + 1)}>count is: {count}</button>
+          <button onClick={() => setCount(count => count + 1)}>count is: {count}</button>
         </p>
         <p>
           Edit <code>App.tsx</code> and save to test HMR updates.

--- a/template-react/src/App.jsx
+++ b/template-react/src/App.jsx
@@ -11,7 +11,7 @@ function App() {
         <img src={logo} className="App-logo" alt="logo" />
         <p>Hello Vite + React!</p>
         <p>
-          <button onClick={() => setCount(count + 1)}>count is: {count}</button>
+          <button onClick={() => setCount(count => count + 1)}>count is: {count}</button>
         </p>
         <p>
           Edit <code>App.jsx</code> and save to test HMR updates.

--- a/template-reason-react/src/App.re
+++ b/template-reason-react/src/App.re
@@ -11,7 +11,7 @@ let make = () => {
       <img src=logo className="App-logo" alt="logo" />
       <p> {React.string("Hello Vite + Reason React")} </p>
       <p>
-        <button onClick={_ => setCount(_ => count + 1)}>
+        <button onClick={_ => setCount(count => count + 1)}>
           {React.string("count is: " ++ string_of_int(count))}
         </button>
       </p>


### PR DESCRIPTION
https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous

> React may batch multiple setState() calls into a single update for performance.
> ……
> To fix it, use a second form of setState() that accepts a function rather than an object. That function will receive the previous state as the first argument, and the props at the time the update is applied as the second argument:

