### PR TITLE
Add .vue module declaration shims file as it give error.

### DIFF
--- a/template-vue-ts/src/shims-vue.d.ts
+++ b/template-vue-ts/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent
+  export default component
+}


### PR DESCRIPTION
`main.ts` gives error `Cannot find module './App.vue' or its corresponding type declarations.ts(2307)`.

After adding the shims file the error stopped.

I see the pr #52  is quoting the same problem. So closing