### PR TITLE
fix: include dist-ssr in default .gitignore

### DIFF
--- a/template-preact-ts/_gitignore
+++ b/template-preact-ts/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 dist
+dist-ssr
 *.local

--- a/template-preact/_gitignore
+++ b/template-preact/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 dist
+dist-ssr
 *.local

--- a/template-react-ts/_gitignore
+++ b/template-react-ts/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 dist
+dist-ssr
 *.local

--- a/template-react/_gitignore
+++ b/template-react/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 dist
+dist-ssr
 *.local

--- a/template-reason-react/_gitignore
+++ b/template-reason-react/_gitignore
@@ -6,4 +6,5 @@ lib/bs
 node_modules
 bundleOutput
 dist
+dist-ssr
 *.local

--- a/template-vue-ts/_gitignore
+++ b/template-vue-ts/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 dist
+dist-ssr
 *.local

--- a/template-vue/_gitignore
+++ b/template-vue/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 dist
+dist-ssr
 *.local


### PR DESCRIPTION
Currently `vite build --ssr` writes to the default output path `dist-ssr/`, but only `dist/` is ignored in the .gitignores.