### PR TITLE
build: ignore node_modules when compiling typescript

### DIFF
--- a/template-vue-ts/tsconfig.json
+++ b/template-vue-ts/tsconfig.json
@@ -9,5 +9,6 @@
     "lib": ["esnext", "dom"],
     "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Add exclude: ["node_modules"] to tsconfig.json for running tsc more efficient. #61